### PR TITLE
Make script work again with newer systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ psexec.exe -s -i regedit /e C:\BTKeys.reg HKEY_LOCAL_MACHINE\SYSTEM\ControlSet00
  8. Run `bluetooth_fix.py --reg_path keys.reg`.
  9. From a terminal with `sudo`, navigate to `/var/lib/bluetooth/<ADAPTOR_MAC_ADDRESS>/` and use `ls` to get the mac addresses similar to the bluetooth device you are trying to pair, and re-name the directory to the new mac displayed in the output from step 8.
  10. Open `/var/lib/bluetooth/<ADAPTOR_MAC>/<DEVICE_MAC>/info` and modify the values as per output from step 8.
- 11. Restart bluetooth with `sudo /etc/init.d/bluetooth restart`.
+ 11. Restart bluetooth with `sudo systemctl restart bluetooth`.
 
 # Developer Notes
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ psexec.exe -s -i regedit /e C:\BTKeys.reg HKEY_LOCAL_MACHINE\SYSTEM\ControlSet00
  5. Turn off bluetooth device(s) and boot back into Linux.
  6. Copy the `BTKeys.reg` file to your Linux filesystem.
  7. Run `clean_reg_file.py /path/to/BTKeys.reg keys.reg` to clean the file (converts encoding to UTF8 and strips quotation marks).
- 8. Run `bluetooth_fix.py keys.reg`.
+ 8. Run `bluetooth_fix.py --reg_path keys.reg`.
  9. From a terminal with `sudo`, navigate to `/var/lib/bluetooth/<ADAPTOR_MAC_ADDRESS>/` and use `ls` to get the mac addresses similar to the bluetooth device you are trying to pair, and re-name the directory to the new mac displayed in the output from step 8.
  10. Open `/var/lib/bluetooth/<ADAPTOR_MAC>/<DEVICE_MAC>/info` and modify the values as per output from step 8.
  11. Restart bluetooth with `sudo /etc/init.d/bluetooth restart`.

--- a/bluetooth_fix.py
+++ b/bluetooth_fix.py
@@ -70,7 +70,7 @@ def _process_reg_file(config):
     """ Process the reg file."""
     sections = config.sections()
     for section in sections:
-        if len(config[section]) != 10:
+        if len(section) < 98:
             continue
         print('\n')
         print('Dir Name: /usr/lib/bluetooth/{}'.format(

--- a/bluetooth_fix.py
+++ b/bluetooth_fix.py
@@ -73,7 +73,7 @@ def _process_reg_file(config):
         if len(section) < 98:
             continue
         print('\n')
-        print('Dir Name: /usr/lib/bluetooth/{}'.format(
+        print('Dir Name: /var/lib/bluetooth/{}'.format(
             _bluetooth_dir_name(section)))
         print('LongTermKey')
         print('  Key: {}'.format(_format_ltk(config[section]['LTK'])))


### PR DESCRIPTION
I found several problems in the scipt, and I think this PR can fix them.

1. Readme states to use `bluetooth_fix.py keys.reg` command, which isn't correct, so I added `--reg_path` that is actually recognized by the script;
2. Most Linux systems use systemd nowadays, so I changed the restart command with a systemd one;
3. On my Windows system, the registry folder for a Bluetooth device does not contain exactly 10 keys, so I made it to include sections with paths longer than or equal to 98 characters (which is the length of `HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Services\BTHPORT\Parameters\Keys\112233445566\112233445566`);
4. On newer Linux systems, the Bluetooth config files are stored in `/var`, so I changed it.